### PR TITLE
Added a check for file is directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -164,12 +164,19 @@ func main() {
 	createBuildDir()
 
 	// If dir is given create update for each file
-	files, err := ioutil.ReadDir(appPath)
-	if err == nil {
-		for _, file := range files {
-			createUpdate(filepath.Join(appPath, file.Name()), file.Name())
+	fi, err := os.Stat(appPath)
+	if err != nil {
+		panic(err)
+	}
+
+	if fi.IsDir() {
+		files, err := ioutil.ReadDir(appPath)
+		if err == nil {
+			for _, file := range files {
+				createUpdate(filepath.Join(appPath, file.Name()), file.Name())
+			}
+			os.Exit(0)
 		}
-		os.Exit(0)
 	}
 
 	createUpdate(appPath, platform)


### PR DESCRIPTION
When a file is given instead of a directory the `os.ReadDir` does not report an error but return an empty file list:

```bash
#  tree
.
├── main.go
└── test

0 directories, 2 files

# cat main.go
package main

import (
	"fmt"
	"io/ioutil"
)

func main() {
	files, err := ioutil.ReadDir("test")
	fmt.Printf("files: %+v // err: %s", files, err)
}

# go run main.go
files: [] // err: %!s(<nil>)
```