### PR TITLE
Update to allow developers to customize the fetching of the update

### DIFF
--- a/selfupdate/requester.go
+++ b/selfupdate/requester.go
@@ -1,0 +1,57 @@
+package selfupdate
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Requester interface allows developers to customize the method in which
+// requests are made to retrieve the version and binary
+type Requester interface {
+	Fetch(url string) (io.ReadCloser, error)
+}
+
+// HTTPRequester is the normal requester that is used and does an HTTP
+// to the url location requested to retrieve the specified data.
+type HTTPRequester struct {
+}
+
+// Fetch will return an HTTP request to the specified url and return
+// the body of the result. An error will occur for a non 200 status code.
+func (httpRequester *HTTPRequester) Fetch(url string) (io.ReadCloser, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("bad http status from %s: %v", url, resp.Status)
+	}
+
+	return resp.Body, nil
+}
+
+// mockRequester used for some mock testing to ensure the requester contract
+// works as specified.
+type mockRequester struct {
+	currentIndex int
+	fetches      []func(string) (io.ReadCloser, error)
+}
+
+func (mr *mockRequester) handleRequest(requestHandler func(string) (io.ReadCloser, error)) {
+	if mr.fetches == nil {
+		mr.fetches = []func(string) (io.ReadCloser, error){}
+	}
+	mr.fetches = append(mr.fetches, requestHandler)
+}
+
+func (mr *mockRequester) Fetch(url string) (io.ReadCloser, error) {
+	if len(mr.fetches) <= mr.currentIndex {
+		return nil, fmt.Errorf("No for currentIndex %d to mock", mr.currentIndex)
+	}
+	current := mr.fetches[mr.currentIndex]
+	mr.currentIndex++
+
+	return current(url)
+}

--- a/selfupdate/selfupdate_test.go
+++ b/selfupdate/selfupdate_test.go
@@ -1,6 +1,79 @@
 package selfupdate
 
-import "testing"
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"testing"
+)
 
-func TestUpdater(t *testing.T) {
+var testHash = sha256.New()
+
+func TestUpdaterFetchMustReturnNonNilReaderCloser(t *testing.T) {
+	mr := &mockRequester{}
+	mr.handleRequest(
+		func(url string) (io.ReadCloser, error) {
+			return nil, nil
+		})
+	updater := createUpdater(mr)
+	err := updater.BackgroundRun()
+	if err != nil {
+		equals(t, "Fetch was expected to return non-nil ReadCloser", err.Error())
+	} else {
+		t.Log("Expected an error")
+		t.Fail()
+	}
+
+}
+
+func TestUpdaterWithEmptyPaloadNoErrorNoUpdate(t *testing.T) {
+	mr := &mockRequester{}
+	mr.handleRequest(
+		func(url string) (io.ReadCloser, error) {
+			equals(t, "http://updates.yourdomain.com/myapp/darwin-amd64.json", url)
+			return newTestReaderCloser("{}"), nil
+		})
+	updater := createUpdater(mr)
+
+	err := updater.BackgroundRun()
+	if err != nil {
+		t.Errorf("Error occured: %#v", err)
+	}
+
+}
+
+func createUpdater(mr *mockRequester) *Updater {
+	return &Updater{
+		CurrentVersion: "1.2",
+		ApiURL:         "http://updates.yourdomain.com/",
+		BinURL:         "http://updates.yourdownmain.com/",
+		DiffURL:        "http://updates.yourdomain.com/",
+		Dir:            "update/",
+		CmdName:        "myapp", // app name
+		Requester:      mr,
+	}
+}
+
+func equals(t *testing.T, expected, actual interface{}) {
+	if expected != actual {
+		t.Log(fmt.Sprintf("Expected: %#v %#v\n", expected, actual))
+		t.Fail()
+	}
+}
+
+type testReadCloser struct {
+	buffer *bytes.Buffer
+}
+
+func newTestReaderCloser(payload string) io.ReadCloser {
+	return &testReadCloser{buffer: bytes.NewBufferString(payload)}
+}
+
+func (trc *testReadCloser) Read(p []byte) (n int, err error) {
+	return trc.buffer.Read(p)
+}
+
+func (trc *testReadCloser) Close() error {
+	return nil
 }


### PR DESCRIPTION
information, diffs and binaries

The specific issue my team is hitting is occurring is io timeouts are happening in http requests. Ideally I'd like a way to be able control the http requests, perhaps to add some code to do an exponential backoff and additional requests. I was going to actually add that into this change, but decided it was best just to have a hook. People may want to do a number of things. Perhaps connect to an endpoint with a cert as another example. I added some basic tests. I can't quite add testing for everything as the osext picks the exe up. Though I though I could at least add some tests as a starting point. Further refactoring can make this easier to test.