### PR TITLE
Example demonstrating how go-selfupdate works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ syntax: glob
 *.log
 public/*
 go-selfupdate
+example/example-server
+example/hello-updater
+example/public/*
+example/deployment/*

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<title>Hello Updater Example Server</title>
+I serve updates of the hello-updater program!

--- a/example/run-example.sh
+++ b/example/run-example.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+echo "This example will compile the hello-updater application a few times with different version strings and demonstrate go-selfupdate's functionality."
+echo  "If the version is 'dev', no update checking will be performed."
+echo  "I'm not sure why go-selfupdate doesn't put the files under the <appname> folder since that seems to be required for checking"
+echo
+
+rm -rf deployment/update deployment/hello* public/hello-updater
+
+echo "Building example-server"; echo
+go build -o example-server src/example-server/main.go
+
+echo "Running example server"; echo
+killall example-server
+./example-server &
+
+read -n 1 -p "Press any key to start." ignored; echo
+
+echo "Building dev version of hello-updater"; echo
+go build -ldflags="-X main.version=dev" -o hello-updater src/hello-updater/main.go
+
+echo "Copying it to deployment folder"; echo
+cp hello-updater deployment/
+
+
+echo "Running deployment/hello-updater"
+deployment/hello-updater
+read -n 1 -p "Press any key to continue." ignored; echo
+echo; echo "=========="; echo
+
+for (( minor=0; minor<=2; minor++ )); do
+    echo "Building hello-updater with version set to 1.$minor"
+    go build -ldflags="-X main.version=1.$minor" -o hello-updater src/hello-updater/main.go
+
+    echo "Running go-update to make update available via example-server"; echo
+    go-selfupdate -o public/hello-updater/ hello-updater 1.$minor
+
+    if (( $minor == 0 )); then
+        echo "Copying version 1.0 to deployment so it can self-update"; echo
+        cp hello-updater deployment/
+        cp hello-updater deployment/hello-updater-1.0
+    fi
+
+    echo "Running deployment/hello-updater"
+    deployment/hello-updater
+    read -n 1 -p "Press any key to continue." ignored; echo
+    echo; echo "=========="; echo
+done
+
+echo "Running deployment/hello-updater-1.0 backup copy"
+deployment/hello-updater-1.0
+read -n 1 -p "Press any key to continue." ignored; echo
+echo; echo "=========="; echo
+
+echo "Building unknown version of hello-updater"; echo
+go build -ldflags="-X main.version=unknown" -o hello-updater src/hello-updater/main.go
+echo "Copying unknown version to deployment so it can self-update"; echo
+cp hello-updater deployment/
+
+echo "Running deployment/hello-updater"
+deployment/hello-updater
+sleep 5
+echo; echo "Re-running deployment/hello-updater"
+deployment/hello-updater
+sleep 5
+echo; echo
+
+echo "Shutting down example-server"
+killall example-server

--- a/example/src/example-server/main.go
+++ b/example/src/example-server/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+    "log"
+    "net/http"
+)
+
+type logHandler struct {
+    handler http.Handler
+}
+
+func (lh *logHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+    log.Printf("\n\texample-server received request %s\n", r.URL.RequestURI())
+    lh.handler.ServeHTTP(rw,r)
+}
+
+func main() {
+    // Simple static webserver with logging:
+    log.Fatal(http.ListenAndServe(":8080", &logHandler{handler:http.FileServer(http.Dir("./public"))}))
+}

--- a/example/src/hello-updater/main.go
+++ b/example/src/hello-updater/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"log"
+	"github.com/sanbornm/go-selfupdate/selfupdate"
+)
+
+var version string
+
+var updater = &selfupdate.Updater{
+    CurrentVersion: version,                   // Manually update the const, or set it using `go build -ldflags="-X main.VERSION=<newver>" -o hello-updater src/hello-updater/main.go`
+    ApiURL:         "http://localhost:8080/",  // The server hosting `$CmdName/$GOOS-$ARCH.json` which contains the checksum for the binary
+    BinURL:         "http://localhost:8080/",  // The server hosting the zip file containing the binary application which is a fallback for the patch method
+    DiffURL:        "http://localhost:8080/",  // The server hosting the binary patch diff for incremental updates
+    Dir:            "update/",                 // The directory created by the app when run which stores the cktime file
+    CmdName:        "hello-updater",           // The app name which is appended to the ApiURL to look for an update
+    ForceCheck: true,                          // For this example, always check for an update unless the version is "dev"
+}
+
+func main() {
+	log.Printf("Hello world I am currently version %v", updater.CurrentVersion)
+	updater.BackgroundRun()
+	log.Printf("Next run, I should be %v", updater.Info.Version)
+}


### PR DESCRIPTION
It took me a bit of playing to figure out how to use go-selfupdate, so I figured I'd share what I learned through an example.
To run, just cd into the example directory and execute the `run-example.sh` script.
The example leaves its files behind so the user can explore the public directory, etc.

Code is donated to the go-selfupdate project with the same license that project uses.
