### PR TITLE
Updater.fetchAndVerifyPatch error

### DIFF
--- a/selfupdate/selfupdate.go
+++ b/selfupdate/selfupdate.go
@@ -154,6 +154,7 @@ func (u *Updater) update() error {
 		} else {
 			if u.DiffURL != "" {
 				log.Println("update: patching binary,", err)
+				return err
 			}
 		}
 


### PR DESCRIPTION
Hi guys,

I think better returns the error if return error in Updater.fetchAndVerifyPatch.
My use case is looping retry update until success update, if fails update, catch the error.

Thanks!