### PR TITLE
Fix: resolve symlinks for bin filepaths

### DIFF
--- a/selfupdate/selfupdate.go
+++ b/selfupdate/selfupdate.go
@@ -187,6 +187,11 @@ func (u *Updater) Update() error {
 	if err != nil {
 		return err
 	}
+
+	if resolvedPath, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolvedPath
+	}
+
 	old, err := os.Open(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
If you run your commands from a symlink, we need to resolve the full symlink path, otherwise we'll just end up replacing the symlink itself and not the binary it was linking to.