### PR TITLE
Update installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Enable your Golang applications to self update.  Inspired by Chrome based on Her
 
 ### Install library and update/patch creation utility
 
-`go get -u github.com/sanbornm/go-selfupdate/...`
+`go install github.com/sanbornm/go-selfupdate/cmd/go-selfupdate@latest`
 
 ### Enable your App to Self Update
 


### PR DESCRIPTION
The current command fails with

```
$ go get -u github.com/sanbornm/go-selfupdate/...
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```