### PR TITLE
support absolute path when use `os.TempDir()`

### DIFF
--- a/selfupdate/selfupdate.go
+++ b/selfupdate/selfupdate.go
@@ -68,6 +68,9 @@ type Updater struct {
 }
 
 func (u *Updater) getExecRelativeDir(dir string) string {
+	if dir[0] == '/' || dir[1] == ':' {
+		return dir
+	}
 	filename, _ := os.Executable()
 	path := filepath.Join(filepath.Dir(filename), dir)
 	return path


### PR DESCRIPTION
``` go
var updater = &selfupdate.Updater{
	CurrentVersion: version,
	ApiURL:         url,
	BinURL:         url,
	DiffURL:        url,
	Dir:            os.TempDir() + "/xxx-updater/",
	CmdName:        name,
	OnSuccessfulUpdate: func() {
		fmt.Println("update success")
	},
}
```